### PR TITLE
chore: evidence - trigger CodeQL and show branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ git commit  # Finalizar la resolución
 | `git branch -a` | Lista todas las ramas (locales/remotas) |
 | `git fetch --all` | Actualiza referencias de ramas remotas |
 | `git log --oneline --graph` | Ver historial compacto |
+
+ CodeQL check and branch protection are active.


### PR DESCRIPTION
## Context
This PR serves as evidence of:
- Branch protection on `main`: PRs are required and direct push is blocked.
- CodeQL active (TS + Python) as a required status check.


## What it includes
- Trivial change in the README to trigger workflows.
- CodeQL runs on this PR.

## Acceptance
- CodeQL checks appear and complete on this PR.
- It is not possible to merge if the checks fail (see rule).
- Screenshots are attached of:
  1) `main` ruleset showing “Require PR”, “Block/Restrict push” and “Require status checks (CodeQL)”.
  2) This PR with the CodeQL checks in green.
